### PR TITLE
Fixed sort on Trade Volume column

### DIFF
--- a/src/components/PairList.tsx
+++ b/src/components/PairList.tsx
@@ -30,8 +30,8 @@ export const PairList: React.FC<PairListProps> = ({ pairs }) => {
   let sortedPairs = [...pairs];
   if (sortColumn && sortOrder) {
     sortedPairs.sort((a, b) => {
-      const valueA = a[sortColumn];
-      const valueB = b[sortColumn];
+      const valueA = Number(a[sortColumn]);
+      const valueB = Number(b[sortColumn]);
 
       if (sortOrder === 'asc') {
         return valueA < valueB ? -1 : 1;


### PR DESCRIPTION
trade_volume was being sorted as a string rather than as a number